### PR TITLE
Halton sampling using LowDiscrepensarySample

### DIFF
--- a/src/simulations/montecarlo.jl
+++ b/src/simulations/montecarlo.jl
@@ -47,15 +47,23 @@ function qmc_samples(sim::SobolSampling, rvs::Integer)
 end
 
 function qmc_samples(sim::HaltonSampling, rvs::Integer)
-    h = HaltonPoint(rvs; length=sim.n)
+ prime = ones(rvs*rvs)
+ prime[1] = 0 
+ pl = 2
+ kl = rvs
+ coprimes = zeros(rvs)
+ while kl>0
+     if prime[pl]==1
+         for i in (pl*pl):pl:(rvs*rvs)
+             prime[i] = 0
+         end
+         kl-=1
+         coprimes[rvs-kl] = pl
+     end
+     pl+=1
+ end
 
-    u = zeros(sim.n, rvs)
-
-    for (i, hp) in enumerate(h)
-        u[i, :] = hp
-    end
-
-    return u
+    return transpose(QuasiMonteCarlo.sample(sim.n, zeros(rvs), ones(rvs), LowDiscrepancySample(coprimes)))
 end
 
 function qmc_samples(sim::LatinHypercubeSampling, rvs::Integer)


### PR DESCRIPTION
I have edited the code that calculates the  prime number  and have reduced one for loop by storing the values directly in the while loop. 
prime variable has the stored the value 1 in the index number which are prime else 0. coprimes variable will store the prime numbers needed as per the number of random variables.