### PR TITLE
Using Primes package

### DIFF
--- a/src/UncertaintyQuantification.jl
+++ b/src/UncertaintyQuantification.jl
@@ -10,6 +10,7 @@ using FiniteDifferences
 using Formatting
 using LinearAlgebra
 using Mustache
+using Primes
 using QuasiMonteCarlo
 using Random
 using Reexport


### PR DESCRIPTION
In order to drop the HaltonSequence package completely, we need to use the Primes package. Using the prime package, the prime numbers are calculated which are needed for sampling using the Halton's Method.